### PR TITLE
Bugfix - copy directory, not link

### DIFF
--- a/deploy-wamcmis
+++ b/deploy-wamcmis
@@ -112,7 +112,7 @@ fi
 
 if [ $skipDeploy = false ]; then
 	echo "Deploying latest changes to staging directory..."
-	cp -R "$targetSymlinkPath" "$targetPath"
+	cp -R "$targetSymlinkPath/" "$targetPath"
 	rsync -a --exclude=".git*" --delete --delete-excluded "$clonePath" "$targetPath"
 	echo "Done deploying latest changes to staging directory"
 fi


### PR DESCRIPTION
The `cp` command from `current` to the new target directory was previously
creating a copy of the symlink, not a copy of the contents of its target.
