### PR TITLE
Test installation profile with `caUtils install`

### DIFF
--- a/bin/test-install
+++ b/bin/test-install
@@ -1,0 +1,29 @@
+#!/bin/bash
+#
+# Installation test script.
+#
+# This script encapsulates an integration test, which installs a profile into a specified database, and confirms there
+# are no errors with the installation.
+#
+
+# Break on any undefined variable or any error.
+set -u
+set -e
+
+# Check setup
+tools_path=`dirname $0`
+$tools_path/check-environment
+
+# Run the installation
+pushd $COLLECTIVEACCESS_HOME >/dev/null
+install_output=`support/bin/caUtils install --hostname=localhost --setup="$tools_path/../conf/test-install/setup-tests.php" --profile-name=wamcmis --admin-email=dev@gaiaresources.com.au`
+popd >/dev/null
+
+# Check result; the best we can do here is to inspect the output and look for a matched regex
+if [[ "$install_output" =~ errors?\ occurred ]]; then
+	echo -e "Errors occurred, full output follows:\n\n$install_output\n\n"
+	exit 1
+else
+	echo -e "Installation successful!\n\n"
+	exit 0
+fi

--- a/conf/test-install/setup.php
+++ b/conf/test-install/setup.php
@@ -1,0 +1,16 @@
+<?php
+
+if (!defined("__CA_DB_HOST__")) {
+	define("__CA_DB_HOST__", 'localhost');
+}
+if (!defined("__CA_DB_USER__")) {
+	define("__CA_DB_USER__", 'ca_test');
+}
+if (!defined("__CA_DB_PASSWORD__")) {
+	define("__CA_DB_PASSWORD__", 'password');
+}
+if (!defined("__CA_DB_DATABASE__")) {
+	define("__CA_DB_DATABASE__", 'ca_test');
+}
+
+require_once(getenv('COLLECTIVEACCESS_HOME') . '/setup.php');


### PR DESCRIPTION
- Simple test script which installs to a database, which is expected
  to exist but to not contain any CA schema.
- More work to do to setup and tear down the test.
