### PR TITLE
Look for setup.php, and error message improvements.

### DIFF
--- a/bin/check-environment
+++ b/bin/check-environment
@@ -8,18 +8,27 @@
 set -u
 
 if ! which caUtils > /dev/null; then
-    echo "You need to have caUtils from the CollectiveAccess installation directory on your PATH"
-    echo "  it should be a file at ./support/bin/caUtils relative to your providence installation"
-    exit 1
+    echo "ERROR: You need to have caUtils from the CollectiveAccess installation directory on your PATH"
+    echo "You can find caUtils in the ./support/bin directory, relative to your providence installation"
+    exit 10
 fi
 echo -e "\tcaUtils found at:\t\t`which caUtils`"
 
 if [ ! -v COLLECTIVEACCESS_HOME ]; then
-    echo "You should have the COLLECTIVEACCESS_HOME environment variable defined"
-    exit 1
+	echo "ERROR: COLLECTIVEACCESS_HOME is not set"
+	echo "The value of the COLLECTIVEACCESS_HOME environment variable should be a directory containing your setup.php file"
+    exit 20
 fi
 if [ ! -d "$COLLECTIVEACCESS_HOME" ]; then
-    echo "The value of the COLLECTIVEACCESS_HOME environment variable should be the path to your CollectiveAccess installation"
-    exit 1
+	echo "ERROR: COLLECTIVEACCESS_HOME is not a directory"
+	echo "The value of the COLLECTIVEACCESS_HOME environment variable should be a directory containing your setup.php file"
+	echo "Current value: $COLLECTIVEACCESS_HOME"
+    exit 21
+fi
+if [ ! -e "$COLLECTIVEACCESS_HOME/setup.php" ]; then
+	echo "ERROR: COLLECTIVEACCESS_HOME does not contain setup.php"
+	echo "The value of the COLLECTIVEACCESS_HOME environment variable should be a directory containing your setup.php file"
+	echo "Current value: $COLLECTIVEACCESS_HOME"
+	exit 22
 fi
 echo -e "\tCOLLECTIVEACCESS_HOME set to:\t$COLLECTIVEACCESS_HOME"


### PR DESCRIPTION
- The check-environment script checks for the COLLECTIVEACCESS_HOME
  variable and ensures it is set to a directory; now it additionally
  looks for the setup.php file under $COLLECTIVEACCESS_HOME.
- Improved consistency and value of error messages.
- Split exit codes so that the actual error condition can be
  determined by calling script (currently not used anywhere, but
  makes sense in a general way).
