### PR TITLE
Strip eps taxonomy

### DIFF
--- a/xslt/strip-eps-taxonomy.xslt
+++ b/xslt/strip-eps-taxonomy.xslt
@@ -17,7 +17,7 @@
 				</label>
 			</labels>
 			<items>
-				<item idno="Animalia" enabled="1" default="0">
+				<item idno="eps_animalia" enabled="1" default="0">
 					<labels>
 						<label locale="en_AU" preferred="1">
 							<name_singular>Animal</name_singular>


### PR DESCRIPTION
- This taxonomy is also pretty large and unwieldy so we should strip it
- from the profile as well
