### PR TITLE
Strip terms from minerals import taxonomies

### DIFF
--- a/xslt/strip-chemical-elements.xslt
+++ b/xslt/strip-chemical-elements.xslt
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+
+	<!--identity template copies everything forward by default-->
+	<xsl:template match="node()|@*">
+		<xsl:copy>
+			<xsl:apply-templates select="node()|@*"/>
+		</xsl:copy>
+	</xsl:template>
+
+	<!--replace the chemical_elements list with a blank list -->
+	<xsl:template match="list[@code = 'chemical_elements']">
+		<list code="chemical_elements" hierarchical="0" system="0" vocabulary="1">
+		<labels>
+			<label locale="en_AU">
+				<name>Chemical Elements</name>
+			</label>
+		</labels>
+		</list>
+	</xsl:template>
+</xsl:stylesheet>

--- a/xslt/strip-host-rock-types.xslt
+++ b/xslt/strip-host-rock-types.xslt
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+
+	<!--identity template copies everything forward by default-->
+	<xsl:template match="node()|@*">
+		<xsl:copy>
+			<xsl:apply-templates select="node()|@*"/>
+		</xsl:copy>
+	</xsl:template>
+
+	<!--replace the host_rock_types list with a blank list -->
+	<xsl:template match="list[@code = 'host_rock_types']">
+		<list code="host_rock_types" hierarchical="0" system="0" vocabulary="1">
+		<labels>
+			<label locale="en_AU">
+				<name>Host Rock</name>
+			</label>
+		</labels>
+		</list>
+	</xsl:template>
+</xsl:stylesheet>

--- a/xslt/strip-minerals.xslt
+++ b/xslt/strip-minerals.xslt
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+
+	<!--identity template copies everything forward by default-->
+	<xsl:template match="node()|@*">
+		<xsl:copy>
+			<xsl:apply-templates select="node()|@*"/>
+		</xsl:copy>
+	</xsl:template>
+
+	<!--replace the minerals list with a blank list -->
+	<xsl:template match="list[@code = 'minerals']">
+		<list code="minerals" hierarchical="0" system="0" vocabulary="1">
+		<labels>
+			<label locale="en_AU">
+				<name>Minerals</name>
+			</label>
+		</labels>
+		</list>
+	</xsl:template>
+</xsl:stylesheet>


### PR DESCRIPTION
These taxonomies are also unwieldy after a full import. Remove their terms and let them be recreated by data imports.
- chemical_elements
- host_rock_types
- minerals
