### PR TITLE
Add type to the list items for taxonomies so that we can use them

### DIFF
--- a/xslt/strip-eps-taxonomy.xslt
+++ b/xslt/strip-eps-taxonomy.xslt
@@ -17,7 +17,7 @@
 				</label>
 			</labels>
 			<items>
-				<item idno="eps_animalia" enabled="1" default="0">
+				<item idno="eps_animalia" enabled="1" default="0" type="scientific_name">
 					<labels>
 						<label locale="en_AU" preferred="1">
 							<name_singular>Animal</name_singular>

--- a/xslt/strip-taxonomy.xslt
+++ b/xslt/strip-taxonomy.xslt
@@ -17,7 +17,7 @@
 				</label>
 			</labels>
 			<items>
-				<item idno="Animalia" enabled="1" default="0">
+				<item idno="Animalia" enabled="1" default="0" type="scientific_name">
 					<labels>
 						<label locale="en_AU" preferred="1">
 							<name_singular>Animal</name_singular>


### PR DESCRIPTION
Tested this with a reset-ca and you can choose these elements.
