### PR TITLE
Add `git fetch` to deploy script.

### DIFF
--- a/bin/deploy-wamcmis
+++ b/bin/deploy-wamcmis
@@ -231,6 +231,7 @@ echo "******** DEPLOYING $mode ********" | tr '[:lower:]' '[:upper:]'
 if [[ "$skipRepoUpdate" != true ]]; then
 	echo "Pulling latest changes from branch '$branch' on remote '$remote' into repository '$repoPath'..."
 	pushd "$repoPath" >/dev/null
+	git fetch
 	git checkout $branch
 	git pull $remote $branch
 	popd >/dev/null


### PR DESCRIPTION
+ We recently switched our deployment branch, and a manual
  `git fetch` was required in staging to make that branch
  available.
+ This adds the `git fetch` to the script so that switching deploy
  branches is not an issue.