### PR TITLE
Update the tables to index for 1.6.x

### DIFF
--- a/bin/rebuild-indexes
+++ b/bin/rebuild-indexes
@@ -10,7 +10,7 @@ fi
 #tables=( )
 if [ "$#" -eq 0 ]; then
 	echo "Defaulting to all tables"
-	tables=( ca_objects ca_occurrences ca_list_items ca_entities ca_relationship_types ca_loans ca_user_groups ca_collections ca_storage_locations ca_users ca_places ca_sets ca_object_representations ca_object_lots ca_orders ca_order_items ca_communications ca_tour_stops ca_comments ca_tags ca_tours ca_movements )
+	tables=( ca_list_items ca_objects ca_relationship_types ca_users ca_user_groups ca_storage_locations ca_places ca_occurrences ca_object_representations ca_entities ca_object_checkouts ca_object_lots ca_tour_stops ca_movements ca_item_tags ca_loans ca_item_comments ca_set_items ca_collections ca_tours ca_sets)
 else
 	tables=( "$@" )
 fi


### PR DESCRIPTION
Commerce order are gone, a few tables renamed. I got the new table list by running:

``` php
caDebug(join(" ", array_map(function($a) { return $a['name'];},$va_table_names)), 'tables', true);
```
at 
https://github.com/kehh/providence/blob/master-fix/app/lib/core/Search/SearchIndexer.php#L190

| Old tables | New Tables |
| ---------- | ------------ |
| ca_collections | ca_collections |
| ca_comments | ca_entities |
| ca_communications | ca_item_comments |
| ca_entities | ca_item_tags |
| ca_list_items | ca_list_items |
| ca_loans | ca_loans |
| ca_movements | ca_movements |
| ca_object_lots | ca_object_checkouts |
| ca_object_representations | ca_object_lots |
| ca_objects | ca_object_representations |
| ca_occurrences | ca_objects |
| ca_order_items | ca_occurrences |
| ca_orders | ca_places |
| ca_places | ca_relationship_types |
| ca_relationship_types | ca_set_items |
| ca_sets | ca_sets |
| ca_storage_locations | ca_storage_locations |
| ca_tags | ca_tour_stops |
| ca_tour_stops | ca_tours |
| ca_tours | ca_user_groups |
| ca_user_groups | ca_users |
| ca_users |  |